### PR TITLE
fixed an error when the schema type is `string`

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -5,4 +5,5 @@ bin/
 .settings/
 .classpath
 .project
+.factorypath
 swagger-codegen-cli-2.3.1.jar

--- a/petstore-example.sh
+++ b/petstore-example.sh
@@ -3,7 +3,7 @@ set -e
 
 mvn clean package
 
-CUSTOM_GEN_JAR=./target/TypescriptBrowser-swagger-codegen-0.0.1-shaded.jar
+CUSTOM_GEN_JAR=./target/TypescriptBrowser-swagger-codegen-*-shaded.jar
 
 java -jar ${CUSTOM_GEN_JAR} generate \
   -l TypescriptBrowser \

--- a/src/main/resources/TypescriptBrowser/api.mustache
+++ b/src/main/resources/TypescriptBrowser/api.mustache
@@ -60,8 +60,9 @@ export class BaseAPI {
                     return transformPropertyNames(result, context.modelPropertyNaming);
                 case 'text':
                     return await response.text() as any as T;
+                default:
+                    return response as any as T;
             }
-            return response as any as T;
         }
         throw response;
     }
@@ -99,21 +100,17 @@ export class BaseAPI {
         return response;
     }
 
-    /*
-        https://swagger.io/docs/specification/2-0/describing-responses/
-
-        The schema keyword is used to describe the response body. A schema can define:
-        object or array – typically used with JSON and XML APIs,
-        a primitive such as a number or string – used for plain text responses,
-        file (see below).
-    */
-    static getResponseType(returnType: string): 'JSON' | 'text' | undefined {
+    /**
+     * https://swagger.io/docs/specification/2-0/describing-responses/
+     *
+     * If the response type for a given API is a 'string' we need to avoid
+     * parsing the response as json because JSON.parse("some string") will
+     * fail when the string isn't actually JSON.
+     */
+    protected getResponseType(returnType: string): ResponseType {
         switch (returnType) {
             case 'string':
                 return 'text'
-            case 'number': // JSON.parse("42.42") -> 42.42
-            case 'object':
-            case 'array':
             default:
                 return 'JSON'
         }
@@ -287,7 +284,7 @@ export class {{classname}} extends BaseAPI {
             body: formData,
             {{/hasFormParams}}
             {{#returnType}}
-            responseType: BaseAPI.getResponseType('{{returnType}}'),
+            responseType: this.getResponseType('{{{returnType}}}'),
             {{/returnType}}
             modelPropertyNaming: '{{modelPropertyNaming}}',
         });
@@ -355,13 +352,15 @@ export interface FetchParams {
     init: RequestInit;
 }
 
+type ResponseType = 'JSON' | 'text';
+
 interface RequestOpts {
     path: string;
     method: HTTPMethod;
     headers: HTTPHeaders;
     query?: HTTPQuery;
     body?: HTTPBody;
-    responseType?: 'JSON' | 'text';
+    responseType?: ResponseType;
     modelPropertyNaming: ModelPropertyNaming;
 }
 

--- a/src/main/resources/TypescriptBrowser/api.mustache
+++ b/src/main/resources/TypescriptBrowser/api.mustache
@@ -54,9 +54,12 @@ export class BaseAPI {
         const { url, init } = this.createFetchParams(context);
         const response = await this.fetchApi(url, init);
         if (response.status >= 200 && response.status < 300) {
-            if (context.responseType === 'JSON') {
-                const result = await response.json() as T;
-                return transformPropertyNames(result, context.modelPropertyNaming);
+            switch(context.responseType) {
+                case 'JSON':
+                    const result = await response.json() as T;
+                    return transformPropertyNames(result, context.modelPropertyNaming);
+                case 'text':
+                    return await response.text() as any as T;
             }
             return response as any as T;
         }
@@ -94,6 +97,26 @@ export class BaseAPI {
             }
         }
         return response;
+    }
+
+    /*
+        https://swagger.io/docs/specification/2-0/describing-responses/
+
+        The schema keyword is used to describe the response body. A schema can define:
+        object or array – typically used with JSON and XML APIs,
+        a primitive such as a number or string – used for plain text responses,
+        file (see below).
+    */
+    static getResponseType(returnType: string): 'JSON' | 'text' | undefined {
+        switch (returnType) {
+            case 'string':
+                return 'text'
+            case 'number': // JSON.parse("42.42") -> 42.42
+            case 'object':
+            case 'array':
+            default:
+                return 'JSON'
+        }
     }
 };
 
@@ -264,7 +287,7 @@ export class {{classname}} extends BaseAPI {
             body: formData,
             {{/hasFormParams}}
             {{#returnType}}
-            responseType: 'JSON',
+            responseType: BaseAPI.getResponseType('{{returnType}}'),
             {{/returnType}}
             modelPropertyNaming: '{{modelPropertyNaming}}',
         });
@@ -338,7 +361,7 @@ interface RequestOpts {
     headers: HTTPHeaders;
     query?: HTTPQuery;
     body?: HTTPBody;
-    responseType?: 'JSON';
+    responseType?: 'JSON' | 'text';
     modelPropertyNaming: ModelPropertyNaming;
 }
 


### PR DESCRIPTION
This PR allow to use schema of type `object`, `array`, `number` and `string` (`file` not supported)

https://swagger.io/docs/specification/2-0/describing-responses/
```
The schema keyword is used to describe the response body. A schema can define:
object or array – typically used with JSON and XML APIs,
a primitive such as a number or string – used for plain text responses,
file (see below).
```

related #2 