### PR TITLE
Revert 4 multipart form data fix

### DIFF
--- a/src/main/resources/TypescriptBrowser/api.mustache
+++ b/src/main/resources/TypescriptBrowser/api.mustache
@@ -163,6 +163,10 @@ export class {{classname}} extends BaseAPI {
         {{/queryParams}}
         const headerParameters: HTTPHeaders = {};
 
+        {{#hasFormParams}}
+        headerParameters['Content-Type'] = 'application/x-www-form-urlencoded';
+
+        {{/hasFormParams}}
         {{#bodyParam}}
         {{^consumes}}
         headerParameters['Content-Type'] = 'application/json';
@@ -222,7 +226,6 @@ export class {{classname}} extends BaseAPI {
         {{/authMethods}}
         {{#hasFormParams}}
         const formData = new FormData();
-        headerParameters['Content-Type'] = 'multipart/form-data';
         {{/hasFormParams}}
         {{#formParams}}
         {{#isListContainer}}

--- a/src/main/resources/TypescriptBrowser/api.mustache
+++ b/src/main/resources/TypescriptBrowser/api.mustache
@@ -163,10 +163,6 @@ export class {{classname}} extends BaseAPI {
         {{/queryParams}}
         const headerParameters: HTTPHeaders = {};
 
-        {{#hasFormParams}}
-        headerParameters['Content-Type'] = 'application/x-www-form-urlencoded';
-
-        {{/hasFormParams}}
         {{#bodyParam}}
         {{^consumes}}
         headerParameters['Content-Type'] = 'application/json';


### PR DESCRIPTION
If a Content-Type is set manually, i get this message```An error occurred during the upload process. Error : no multipart boundary param in Content-Type```

But if i remove the line ```headerParameters['Content-Type'] = 'multipart/form-data';``` it's works because `fetch` [add a correct Content-Type for a formData](https://github.com/github/fetch/issues/505) 
Example:
```content-type: multipart/form-data; boundary=----WebKitFormBoundaryIt5Gvz8CsZTSAjRY```